### PR TITLE
Return plot images as native MCP ImageContent instead of base64 text

### DIFF
--- a/.claude/skills/research-insights/SKILL.md
+++ b/.claude/skills/research-insights/SKILL.md
@@ -23,7 +23,7 @@ This project trains a chess-playing transformer using **GRPO (Group Relative Pol
 ### Required Tools
 - **Read**: Examine source code files (always include line numbers in findings)
 - **Grep/Glob**: Search codebase for patterns and files
-- **WandB MCP**: Query training metrics (`list_runs`, `get_run_metrics`, `get_run_summary`, `compare_runs`)
+- **WandB MCP**: Query training metrics (`list_runs`, `get_run_metrics`, `get_run_summary`, `compare_runs`, `get_plots` — returns images as native `ImageContent` for token-efficient viewing)
 
 ### Optional Tools
 - **WebSearch**: Research ML concepts, find papers, compare approaches

--- a/mcp_wandb_server/README.md
+++ b/mcp_wandb_server/README.md
@@ -8,7 +8,7 @@ This MCP server enables coding agents to query wandb data including:
 - Training metrics (loss, rewards, KL divergence, etc.)
 - Evaluation results (Stockfish scores, Elo differences, win rates)
 - Run summaries and hyperparameters
-- Plot and image data with base64-encoded images for direct viewing
+- Plot and image data returned as native `ImageContent` for token-efficient viewing
 - Run comparisons
 
 ## Installation
@@ -230,29 +230,28 @@ Get summary statistics for a run including best/worst values, final values, and 
 ```
 
 ### `get_plots`
-Retrieve plot/image data from wandb runs with base64-encoded image data for direct viewing by agents.
+Retrieve plot/image data from wandb runs. Images are returned as native MCP `ImageContent` (vision tokens) instead of base64 text, reducing token cost by ~30-60x per image.
 
 **Parameters:**
 - `run_id` (required): WandB run ID or name
 - `plot_type` (optional): Filter by plot type (image, other)
-- `include_image_data` (optional): If true, download and include base64-encoded image data (default: true)
+- `include_image_data` (optional): If true, download images (default: true)
+- `max_dimension` (optional): Max pixel dimension for downscaling (default: 800, 0 to disable)
 
 **Returns:**
-- Plot metadata (name, size, URL)
-- Base64-encoded image data in `image_data` field
-- Data URI in `data_uri` field (ready for embedding: `data:image/png;base64,...`)
-- MIME type in `mime_type` field
+- `TextContent`: Plot metadata JSON (name, size, URL, type for each plot)
+- `ImageContent`: One per image file, downscaled to `max_dimension` pixels, as native vision content
 
 **Example:**
 ```json
 {
   "run_id": "chess-grpo-20240101-1200-abcd",
   "plot_type": "image",
-  "include_image_data": true
+  "max_dimension": 800
 }
 ```
 
-**Note:** When `include_image_data` is true, agents can directly view and analyze the plot images. The images are provided as base64-encoded strings and data URIs that can be embedded or displayed.
+**Note:** SVG files are included in metadata but not returned as `ImageContent`. Images are automatically downscaled to reduce token usage — set `max_dimension` to 0 to get full-resolution images.
 
 ### `compare_runs`
 Compare metrics across multiple runs.


### PR DESCRIPTION
This pull request updates the WandB MCP server and utilities to return plot images as native `ImageContent` objects (using vision tokens) instead of base64-encoded strings. This change makes image handling more efficient and reduces token usage for agents consuming plot data. The update also introduces optional image downscaling and adjusts tool signatures and documentation accordingly.

The most important changes are:

**API and Data Format Improvements:**

* The `get_plots` tool now returns images as native `ImageContent` objects (vision tokens), instead of base64-encoded strings, which reduces token usage by 30–60x per image. Images can be automatically downscaled to a configurable maximum dimension for further efficiency. (`mcp_wandb_server/tools.py`, `mcp_wandb_server/server.py`, `mcp_wandb_server/utils.py`, [[1]](diffhunk://#diff-47a849af7537b146679c8b92b04fa46738a29653a18fbb883df882f28c04c3d3L176-R234) [[2]](diffhunk://#diff-91206316af33600c92d61b50cb9eed72bbac439883ec66e4da736cb2f756a5c9L128-R144) [[3]](diffhunk://#diff-2b167fca86ec81ab029987ebd4819629b43b1d4c5eba3e446a0e52b649a78b85L92-R191)
* The tool API and documentation are updated to reflect the new return type and parameters, including a new `max_dimension` argument for image downscaling and clarification that SVGs are included only as metadata. (`mcp_wandb_server/README.md`, `.claude/skills/research-insights/SKILL.md`, [[1]](diffhunk://#diff-020e5b089d337492e201ae314784775fe4e6398bacbcc05f288d7a132cc7a5daL11-R11) [[2]](diffhunk://#diff-020e5b089d337492e201ae314784775fe4e6398bacbcc05f288d7a132cc7a5daL233-R254) [[3]](diffhunk://#diff-c8a126498e1f441faeb738cc14d79844501c56a4de7f0de900698cc4068cbfffL26-R26)

**Code and Type Adjustments:**

* The server and tool handler signatures are updated to support returning both `TextContent` and `ImageContent` types, and the tool listing includes the new parameters. (`mcp_wandb_server/server.py`, [[1]](diffhunk://#diff-91206316af33600c92d61b50cb9eed72bbac439883ec66e4da736cb2f756a5c9L6-R6) [[2]](diffhunk://#diff-91206316af33600c92d61b50cb9eed72bbac439883ec66e4da736cb2f756a5c9R99-R103) [[3]](diffhunk://#diff-91206316af33600c92d61b50cb9eed72bbac439883ec66e4da736cb2f756a5c9L128-R144)
* The plot formatting utility is refactored to separate metadata extraction from image byte downloading, and a new utility function for image downscaling is introduced. (`mcp_wandb_server/utils.py`, [[1]](diffhunk://#diff-2b167fca86ec81ab029987ebd4819629b43b1d4c5eba3e446a0e52b649a78b85L2-R2) [[2]](diffhunk://#diff-2b167fca86ec81ab029987ebd4819629b43b1d4c5eba3e446a0e52b649a78b85L92-R191)

**Behavioral Changes:**

* Images are now downscaled by default to 800 pixels on the largest dimension, with the option to disable downscaling. SVG files are not returned as images but are included in metadata. (`mcp_wandb_server/tools.py`, [[1]](diffhunk://#diff-47a849af7537b146679c8b92b04fa46738a29653a18fbb883df882f28c04c3d3L176-R234) [[2]](diffhunk://#diff-2b167fca86ec81ab029987ebd4819629b43b1d4c5eba3e446a0e52b649a78b85L92-R191)

These changes make the WandB MCP server more efficient and agent-friendly for image-based workflows.